### PR TITLE
✨🔒 Add authentication functionality to login and logout

### DIFF
--- a/BUpms/components/Login/Form.vue
+++ b/BUpms/components/Login/Form.vue
@@ -94,6 +94,9 @@ const loginFunc = async () => {
     }
     const { email, password } = data.data;
     const auth = await pb.collection('Users_tbl').authWithPassword(email, password)
+    if (auth) {
+      navigateTo(pb.authStore.model?.role === 'student' ? '/Client' : pb.authStore.model?.role === 'officer' ? '/Officer' : pb.authStore.model?.role === 'admin' ? '/Admin' : '/');
+    }
   } catch (e) {
     console.log(e);
   }

--- a/BUpms/composables/pocketbase.ts
+++ b/BUpms/composables/pocketbase.ts
@@ -3,5 +3,13 @@ import PocketBase from 'pocketbase'
 const pb = new PocketBase('https://bupms.pockethost.io')
 
 export const usePocketbase = () => {
+  const listener = pb.authStore.onChange(() => {
+    if (pb.authStore.model) {
+      console.log('logged in')
+    } else {
+      console.log('logged out')
+    }
+  })
+
   return pb
 }

--- a/BUpms/layouts/Landing.vue
+++ b/BUpms/layouts/Landing.vue
@@ -14,8 +14,9 @@
                 <img src="assets/BU_title.png" alt="" class="object-contain min-w-32">
                 <div class="header-2-wrapper flex place-self-center gap-x-5 px-3 min-w-32 ">
                     <div class="name-container flex place-items-center text-sky-500 font-semibold text-sm md:text-2xl ">
-                        Welcome, User
+                        Welcome, {{ user.username }}
                     </div>
+                    <button @click="logout">Logout</button>
                     <div @click="show_alert_notify" class="notification-container cursor-pointer relative ">
                         <IconsNotification></IconsNotification>
                         <div class="notification h-3 w-3 bg-orange-500 rounded-full absolute top-0 right-0"></div>
@@ -42,20 +43,27 @@
     background-color: skyblue;
 }
 </style>
-<script>
+<script setup>
 
-export default {
-    name: 'Landing',
-    data() {
-        return {
-            alertIsClicked: false,
-        }
-    },
-    methods: {
-        show_alert_notify() {
-            this.alertIsClicked = !this.alertIsClicked
-        }
-    },
+const pb = usePocketbase();
+const alertIsClicked = ref(false);
+const user = ref(pb.authStore.model);
 
-}
+const show_alert_notify = () => {
+    alertIsClicked.value = !alertIsClicked.value;
+};
+
+const logout = () => {
+    const pb = usePocketbase();
+    const router = useRouter();
+
+    pb.authStore.clear();
+    router.push('/');
+};
+
+defineExpose({
+    alertIsClicked,
+    show_alert_notify,
+    logout
+});
 </script>

--- a/BUpms/plugins/auth.ts
+++ b/BUpms/plugins/auth.ts
@@ -1,10 +1,10 @@
 
 export default defineNuxtPlugin((nuxtApp) => {
-    const store = useMyAuthStoreStore()
+    const pb = usePocketbase()
 
     return {
         provide: {
-            auth: store.isLoggedIn
+            auth: pb.authStore.isValid ? pb.authStore.model : false
         }
     }
 })

--- a/BUpms/stores/authStore.ts
+++ b/BUpms/stores/authStore.ts
@@ -4,7 +4,11 @@ const pb = usePocketbase()
 
 export const useMyAuthStoreStore = defineStore('myAuthStoreStore', {
   state: () => ({
-    isLoggedIn: pb.authStore.model,
+    isLoggedIn: false
   }),
-  actions: {}
+  actions: {
+    setIsLoggedIn(value: boolean) {
+      this.isLoggedIn = value
+    }
+  }
 })


### PR DESCRIPTION
- Add navigation logic to redirect users to appropriate pages based on their role (student, officer, admin) after successful login
- Implement a listener to track login/logout status and update the UI accordingly
- Add a logout button to the Landing page to allow users to log out
- Remove the `isLoggedIn` state from the `authStore` and instead use the `pb.authStore.model` directly to determine the login status
- Update the `auth` plugin to provide the authenticated user model or `false` if not logged in